### PR TITLE
Changed amber_cmd to amber-cmd to in Dockerfile

### DIFF
--- a/src/templates/app/Dockerfile.ecr
+++ b/src/templates/app/Dockerfile.ecr
@@ -2,9 +2,9 @@ FROM drujensen/crystal:0.23.0
 
 ENV AMBER_VERSION <%= VERSION %>
 
-RUN curl -L https://github.com/Amber-Crystal/amber_cmd/archive/v$AMBER_VERSION.tar.gz | tar xvz -C /usr/local/share/. && cd /usr/local/share/amber_cmd-$AMBER_VERSION && crystal deps && make
+RUN curl -L https://github.com/amber-crystal/amber-cmd/archive/v$AMBER_VERSION.tar.gz | tar xvz -C /usr/local/share/. && cd /usr/local/share/amber-cmd-$AMBER_VERSION && crystal deps && make
 
-RUN ln -sf /usr/local/share/amber_cmd-$AMBER_VERSION/bin/amber /usr/local/bin/amber
+RUN ln -sf /usr/local/share/amber-cmd-$AMBER_VERSION/bin/amber /usr/local/bin/amber
 
 WORKDIR /app/user
 

--- a/src/templates/app/config/routes.cr
+++ b/src/templates/app/config/routes.cr
@@ -4,8 +4,8 @@ Amber::Server.instance.config do |app|
     # A plug accepts an instance of HTTP::Handler
     plug Amber::Pipe::Logger.new
     plug Amber::Pipe::Session.new
-    plug Amber::Pipe::Flash.new
-    # plug Amber::Pipe::CSRF.new
+    # plug Amber::Pipe::Flash.new
+    plug Amber::Pipe::CSRF.new
   end
 
   # All static content will run these transformations

--- a/src/templates/scaffold/src/views/{{name}}/_form.ecr.ecr
+++ b/src/templates/scaffold/src/views/{{name}}/_form.ecr.ecr
@@ -8,6 +8,7 @@
 
 <%="<"%>%- action = (<%= @name %>.id ? "/<%= @name %>s/" + <%= @name %>.id.to_s : "/<%= @name %>s") %>
 <form action="<%="<"%>%= action %>" method="post">
+  <%="<"%>%= csrf_tag %>
   <%="<"%>%- if <%= @name %>.id %>
   <input type="hidden" name="_method" value="patch" />
   <%="<"%>%- end %>

--- a/src/templates/scaffold/src/views/{{name}}/_form.slang.ecr
+++ b/src/templates/scaffold/src/views/{{name}}/_form.slang.ecr
@@ -5,6 +5,7 @@
 
 - action = (<%= @name %>.id ? "/<%= @name %>s/" + <%= @name %>.id.to_s : "/<%= @name %>s")
 form action="#{ action }" method="post"
+  == csrf_tag
   - if <%= @name %>.id
     input type="hidden" name="_method" value="patch"
 <% @fields.reject{|f| f.hidden }.each do |field| -%>


### PR DESCRIPTION
I'm trying to normalize our project names into the format that we've all previously agreed upon.

Projects names are in the format:    `project-name`
Files and folders are in the format:  `file-name`