### PR TITLE
Make font-families consistent

### DIFF
--- a/src/templates/app/public/stylesheets/main.css
+++ b/src/templates/app/public/stylesheets/main.css
@@ -2,7 +2,7 @@
  * Globals
  */
 body {
-  font-family: Georgia, "Times New Roman", Times, serif;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   color: #555;
 }
 


### PR DESCRIPTION
I'm not sure if it's intentional, but font-family's inconsistency makes me a bit unconfortable.

```
body {
  font-family: Georgia, "Times New Roman", Times, serif;
  color: #555;
}

h1, .h1,
h2, .h2,
h3, .h3,
h4, .h4,
h5, .h5,
h6, .h6 {
  margin-top: 0;
  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
  font-weight: normal;
  color: #333;
}
```

![screenshot from 2017-08-20 20-23-22](https://user-images.githubusercontent.com/6219390/29494475-18cfb9f4-85e6-11e7-9d0f-cd94673aa3e3.png)

If this is intentional, just ignore and close this pull request please.